### PR TITLE
Add tracks by batch of 50 to avoid errors

### DIFF
--- a/spotify-restore.py
+++ b/spotify-restore.py
@@ -262,15 +262,18 @@ def get_deezer_playlists(next):
 	return 1 if okay, -1 if not
 '''
 def add_tracks(playlistid, tracklist):
-	strlist = ','.join(str(e) for e in tracklist)
-	params = urllib.parse.urlencode({'songs':strlist}).encode('UTF-8')
-	url = 'https://api.deezer.com/playlist/'+str(playlistid)+'/tracks?access_token='+token
-	f = urllib.request.urlopen(url, data=params)
-	fstr = f.read().decode('utf-8')
-	if fstr == "true":
-		return 1
-	else:
-		return -1
+	batchsize = 50
+	for i in range(0, len(tracklist), batchsize):
+		tracklist_batch = tracklist[i:i+batchsize]
+		strlist = ','.join(str(e) for e in tracklist_batch)
+		params = urllib.parse.urlencode({'songs':strlist}).encode('UTF-8')
+		url = 'https://api.deezer.com/playlist/'+str(playlistid)+'/tracks?access_token='+token
+		f = urllib.request.urlopen(url, data=params)
+		fstr = f.read().decode('utf-8')
+		if fstr == "true":
+			return 1
+		else:
+			return -1
 
 '''
 	WORK IT HARDER


### PR DESCRIPTION
If a playlist contains a lot of tracks, it triggers an error when adding them.
Adding them by batch of 50 solves the problem :-)
